### PR TITLE
Focus task input on mount and after drag

### DIFF
--- a/static/backbone-updater.js
+++ b/static/backbone-updater.js
@@ -4,8 +4,9 @@ define(["sortable"], function(sortable) {
       var component = this;
       this.props.tasks.fetch();
       $('.items').sortable({
-        forcePlaceholderSize: true
+        forcePlaceholderSize: true,
       }).bind('sortupdate', function(e, ui) {
+        $('input:first').focus();
         var maxSort = component.props.tasks.length - 1;
 
         ui.endparent.children().each(function(e) {

--- a/static/taskInput.jsx
+++ b/static/taskInput.jsx
@@ -1,5 +1,9 @@
 define(["react"], function(React) {
   return React.createClass({
+    componentDidMount: function() {
+      this.refs.text.getDOMNode().focus();
+    },
+
     handleTaskSubmit: function(text) {
       this.props.tasks.create({
         text: text


### PR DESCRIPTION
As mentioned in #7, as a small new UX nicety I implemented autofocus of the task input field when the page loads and after a task is reordered so it is possible to quickly add another task.

This is implemented by bypassing react and interacting with the DOM, which is fine to do in this case because it is necessary, but should be done as little as possible because first, react contains it's own abstractions above the DOM, and second, this could slow down the app because the DOM can be slow and bypasses the diffing and update algorithm that react is able to use to get the best performance for large pages.

A note on my drag and drop implementation: it is very hacky and just an example of trying things three years ago (when react was newer) until something worked. There are many better drop in components for it now that abstract drag-and-drop much better, but I'm leaving it in to show my ability to work around problems.

What it does is basically integrate a jQuery plugin with react by just making the react component "sortable" (even though it doesn't know that it is) [backbone-updater.js:6] and every time it has been reordered, changing the model to reflect the new position [line 14] and forcing an update to the component [line 18]. It seems to work pretty well though!